### PR TITLE
feat: add channel whitelist functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,4 +191,7 @@ cython_debug/
 #  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
-.cursorindexingignore.claude/mcp.json
+.cursorindexingignore
+
+# Claude Code configuration (contains sensitive information)
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,3 +141,54 @@ The project uses GitHub Actions for continuous integration:
 - **Coverage**: pytest-cov with Codecov integration
 
 All PRs must pass CI checks before merging.
+
+## Test-Driven Development (TDD) Approach
+
+When implementing new features, follow this TDD workflow:
+
+### 1. Write Tests First
+- Create comprehensive test cases that describe the expected behavior
+- Include both positive and negative test scenarios
+- Write tests for edge cases and error conditions
+- Ensure tests initially fail (red phase)
+
+### 2. Implement Minimal Code
+- Write the minimal code necessary to make tests pass
+- Focus on functionality first, optimization later
+- Ensure all tests pass (green phase)
+
+### 3. Refactor and Improve
+- Clean up code while maintaining test coverage
+- Improve performance and readability
+- Ensure tests continue to pass (refactor phase)
+
+### TDD Example Workflow
+```bash
+# 1. Create failing tests
+uv run pytest tests/test_new_feature.py -v  # Should fail
+
+# 2. Implement feature
+# Edit source code to make tests pass
+
+# 3. Verify tests pass
+uv run pytest tests/test_new_feature.py -v  # Should pass
+
+# 4. Run all tests to ensure no regressions
+uv run pytest -v
+
+# 5. Run code quality checks
+uv run ruff check . && uv run mypy src
+```
+
+### Benefits of TDD in This Project
+- **Quality Assurance**: Ensures all features have test coverage from the start
+- **Documentation**: Tests serve as living documentation of expected behavior
+- **Regression Prevention**: Prevents breaking existing functionality
+- **Design Improvement**: Forces thinking about API design before implementation
+- **Confidence**: Enables safe refactoring and code improvements
+
+### Test Categories
+- **Unit Tests**: Test individual components in isolation
+- **Integration Tests**: Test component interactions
+- **Configuration Tests**: Test environment variable handling and validation
+- **Error Handling Tests**: Test failure scenarios and edge cases

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -20,3 +20,9 @@ ADK_APP_NAME=my-slack-bot
 # Optional: Logging Level
 # Options: DEBUG, INFO, WARNING, ERROR
 LOGGING_LEVEL=INFO
+
+# Optional: Comma-separated list of channel IDs where bot is allowed to respond
+# If not set, bot will respond in all channels and DMs
+# If set, bot will only respond in specified channels (including DMs if DM channel IDs are included)
+# Example: ALLOWED_CHANNELS=C1234567890,C0987654321,D1122334455
+ALLOWED_CHANNELS=

--- a/src/adk_slack_adapter/app_runner.py
+++ b/src/adk_slack_adapter/app_runner.py
@@ -77,6 +77,7 @@ class AdkSlackAppRunner:
         self.slack_event_processor = SlackEventProcessor(
             interaction_flow=self.interaction_flow,
             bot_user_id=self.config.slack_bot_user_id,
+            allowed_channels=self.config.allowed_channels,
         )
         logger.debug("Slack Event Processor initialized.")
 

--- a/src/adk_slack_adapter/features/slack_event_processor.py
+++ b/src/adk_slack_adapter/features/slack_event_processor.py
@@ -23,7 +23,10 @@ class SlackEventProcessor:
     """
 
     def __init__(
-        self, interaction_flow: InteractionFlow, bot_user_id: str | None, allowed_channels: list[str] | None = None
+        self,
+        interaction_flow: InteractionFlow,
+        bot_user_id: str | None,
+        allowed_channels: list[str] | None = None,
     ) -> None:
         """
         Initialize the SlackEventProcessor.
@@ -82,7 +85,9 @@ class SlackEventProcessor:
         # Check channel whitelist (applies to both channels and DMs when configured)
         if self.allowed_channels is not None:
             if channel_id not in self.allowed_channels:
-                logger.debug(f"Channel {channel_id} is not in allowed channels list. Ignoring message.")
+                logger.debug(
+                    f"Channel {channel_id} is not in allowed channels list. Ignoring message."
+                )
                 return
         current_message_has_mention = (
             f"<@{self.bot_user_id}>" in text if self.bot_user_id else False

--- a/src/adk_slack_adapter/infrastructure/config.py
+++ b/src/adk_slack_adapter/infrastructure/config.py
@@ -20,6 +20,7 @@ class AdkSlackConfig:
         slack_bot_user_id: Bot's user ID for mention detection
         adk_app_name: Name of the ADK application
         logging_level: Logging level (DEBUG, INFO, WARNING, ERROR)
+        allowed_channels: List of channel IDs where bot is allowed to respond (None means all channels)
     """
 
     slack_bot_token: str | None = None
@@ -27,6 +28,7 @@ class AdkSlackConfig:
     slack_bot_user_id: str | None = None
     adk_app_name: str = "adk_slack_agent"
     logging_level: str = "INFO"
+    allowed_channels: list[str] | None = None
 
     def __post_init__(self) -> None:
         if self.slack_bot_token is None:
@@ -41,6 +43,15 @@ class AdkSlackConfig:
             self.adk_app_name = _adk_app_name_env
 
         self.logging_level = os.environ.get("LOGGING_LEVEL", self.logging_level).upper()
+
+        # Parse allowed channels from environment variable
+        if self.allowed_channels is None:
+            allowed_channels_env = os.environ.get("ALLOWED_CHANNELS")
+            if allowed_channels_env:
+                # Split by comma and strip whitespace
+                self.allowed_channels = [
+                    channel.strip() for channel in allowed_channels_env.split(",") if channel.strip()
+                ]
 
     def validate(self) -> None:
         """

--- a/src/adk_slack_adapter/infrastructure/config.py
+++ b/src/adk_slack_adapter/infrastructure/config.py
@@ -50,7 +50,9 @@ class AdkSlackConfig:
             if allowed_channels_env:
                 # Split by comma and strip whitespace
                 self.allowed_channels = [
-                    channel.strip() for channel in allowed_channels_env.split(",") if channel.strip()
+                    channel.strip()
+                    for channel in allowed_channels_env.split(",")
+                    if channel.strip()
                 ]
 
     def validate(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,3 +100,47 @@ class TestAdkSlackConfig:
         )
         config.validate()
         assert "SLACK_BOT_USER_ID is not set" in caplog.text
+
+    def test_allowed_channels_from_env(self):
+        """Test that allowed channels are loaded from environment variable."""
+        with patch.dict(
+            os.environ,
+            {
+                "SLACK_BOT_TOKEN": "xoxb-test-token",
+                "SLACK_APP_TOKEN": "xapp-test-token",
+                "ALLOWED_CHANNELS": "C1234567,C2345678, C3456789 ",
+            },
+        ):
+            config = AdkSlackConfig()
+            assert config.allowed_channels == ["C1234567", "C2345678", "C3456789"]
+
+    def test_allowed_channels_empty_env(self):
+        """Test that empty allowed channels environment variable results in None."""
+        with patch.dict(
+            os.environ,
+            {
+                "SLACK_BOT_TOKEN": "xoxb-test-token",
+                "SLACK_APP_TOKEN": "xapp-test-token",
+                "ALLOWED_CHANNELS": "",
+            },
+        ):
+            config = AdkSlackConfig()
+            assert config.allowed_channels is None
+
+    def test_allowed_channels_not_set(self):
+        """Test that allowed channels defaults to None when not set."""
+        config = AdkSlackConfig()
+        assert config.allowed_channels is None
+
+    def test_allowed_channels_constructor_override(self):
+        """Test that constructor values override environment variables for allowed channels."""
+        with patch.dict(
+            os.environ,
+            {
+                "ALLOWED_CHANNELS": "C1111111,C2222222",
+            },
+        ):
+            config = AdkSlackConfig(
+                allowed_channels=["C9999999", "C8888888"]
+            )
+            assert config.allowed_channels == ["C9999999", "C8888888"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,7 +140,5 @@ class TestAdkSlackConfig:
                 "ALLOWED_CHANNELS": "C1111111,C2222222",
             },
         ):
-            config = AdkSlackConfig(
-                allowed_channels=["C9999999", "C8888888"]
-            )
+            config = AdkSlackConfig(allowed_channels=["C9999999", "C8888888"])
             assert config.allowed_channels == ["C9999999", "C8888888"]

--- a/tests/test_slack_event_processor.py
+++ b/tests/test_slack_event_processor.py
@@ -15,9 +15,11 @@ class TestSlackEventProcessor:
     def mock_interaction_flow(self):
         """Create a mock InteractionFlow."""
         mock_flow = MagicMock(spec=InteractionFlow)
+
         # Mock the async generator
         async def mock_response_stream():
             yield "テスト応答です"
+
         mock_flow.get_agent_response_stream.return_value = mock_response_stream()
         return mock_flow
 
@@ -37,15 +39,14 @@ class TestSlackEventProcessor:
         processor = SlackEventProcessor(
             interaction_flow=mock_interaction_flow,
             bot_user_id="U123456",
-            allowed_channels=allowed_channels
+            allowed_channels=allowed_channels,
         )
         assert processor.allowed_channels == allowed_channels
 
     def test_init_without_allowed_channels(self, mock_interaction_flow):
         """Test SlackEventProcessor initialization without allowed channels (all channels allowed)."""
         processor = SlackEventProcessor(
-            interaction_flow=mock_interaction_flow,
-            bot_user_id="U123456"
+            interaction_flow=mock_interaction_flow, bot_user_id="U123456"
         )
         assert processor.allowed_channels is None
 
@@ -58,7 +59,7 @@ class TestSlackEventProcessor:
         processor = SlackEventProcessor(
             interaction_flow=mock_interaction_flow,
             bot_user_id="U123456",
-            allowed_channels=allowed_channels
+            allowed_channels=allowed_channels,
         )
 
         event_data = {
@@ -66,7 +67,7 @@ class TestSlackEventProcessor:
             "channel": "C1234567",  # Allowed channel
             "user": "U999999",
             "text": "<@U123456> こんにちは",
-            "ts": "1234567890.123"
+            "ts": "1234567890.123",
         }
 
         await processor.process_message_event(event_data, mock_say_fn, mock_client)
@@ -85,7 +86,7 @@ class TestSlackEventProcessor:
         processor = SlackEventProcessor(
             interaction_flow=mock_interaction_flow,
             bot_user_id="U123456",
-            allowed_channels=allowed_channels
+            allowed_channels=allowed_channels,
         )
 
         event_data = {
@@ -93,7 +94,7 @@ class TestSlackEventProcessor:
             "channel": "C9999999",  # Not in allowed channels
             "user": "U999999",
             "text": "<@U123456> こんにちは",
-            "ts": "1234567890.123"
+            "ts": "1234567890.123",
         }
 
         await processor.process_message_event(event_data, mock_say_fn, mock_client)
@@ -111,7 +112,7 @@ class TestSlackEventProcessor:
         processor = SlackEventProcessor(
             interaction_flow=mock_interaction_flow,
             bot_user_id="U123456",
-            allowed_channels=None  # No whitelist
+            allowed_channels=None,  # No whitelist
         )
 
         event_data = {
@@ -119,7 +120,7 @@ class TestSlackEventProcessor:
             "channel": "C9999999",  # Any channel should work
             "user": "U999999",
             "text": "<@U123456> こんにちは",
-            "ts": "1234567890.123"
+            "ts": "1234567890.123",
         }
 
         await processor.process_message_event(event_data, mock_say_fn, mock_client)
@@ -138,7 +139,7 @@ class TestSlackEventProcessor:
         processor = SlackEventProcessor(
             interaction_flow=mock_interaction_flow,
             bot_user_id="U123456",
-            allowed_channels=allowed_channels
+            allowed_channels=allowed_channels,
         )
 
         event_data = {
@@ -146,7 +147,7 @@ class TestSlackEventProcessor:
             "channel": "D9999999",  # DM channel (not in whitelist)
             "user": "U999999",
             "text": "こんにちは",
-            "ts": "1234567890.123"
+            "ts": "1234567890.123",
         }
 
         await processor.process_message_event(event_data, mock_say_fn, mock_client)
@@ -165,7 +166,7 @@ class TestSlackEventProcessor:
         processor = SlackEventProcessor(
             interaction_flow=mock_interaction_flow,
             bot_user_id="U123456",
-            allowed_channels=allowed_channels
+            allowed_channels=allowed_channels,
         )
 
         event_data = {
@@ -173,7 +174,7 @@ class TestSlackEventProcessor:
             "channel": "D9999999",  # DM channel (in whitelist)
             "user": "U999999",
             "text": "こんにちは",
-            "ts": "1234567890.123"
+            "ts": "1234567890.123",
         }
 
         await processor.process_message_event(event_data, mock_say_fn, mock_client)

--- a/tests/test_slack_event_processor.py
+++ b/tests/test_slack_event_processor.py
@@ -1,0 +1,184 @@
+"""Tests for SlackEventProcessor."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adk_slack_adapter.features.interaction_flow import InteractionFlow
+from adk_slack_adapter.features.slack_event_processor import SlackEventProcessor
+
+
+class TestSlackEventProcessor:
+    """Test cases for SlackEventProcessor."""
+
+    @pytest.fixture
+    def mock_interaction_flow(self):
+        """Create a mock InteractionFlow."""
+        mock_flow = MagicMock(spec=InteractionFlow)
+        # Mock the async generator
+        async def mock_response_stream():
+            yield "テスト応答です"
+        mock_flow.get_agent_response_stream.return_value = mock_response_stream()
+        return mock_flow
+
+    @pytest.fixture
+    def mock_say_fn(self):
+        """Create a mock say function."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock AsyncWebClient."""
+        return AsyncMock()
+
+    def test_init_with_allowed_channels(self, mock_interaction_flow):
+        """Test SlackEventProcessor initialization with allowed channels."""
+        allowed_channels = ["C1234567", "C2345678"]
+        processor = SlackEventProcessor(
+            interaction_flow=mock_interaction_flow,
+            bot_user_id="U123456",
+            allowed_channels=allowed_channels
+        )
+        assert processor.allowed_channels == allowed_channels
+
+    def test_init_without_allowed_channels(self, mock_interaction_flow):
+        """Test SlackEventProcessor initialization without allowed channels (all channels allowed)."""
+        processor = SlackEventProcessor(
+            interaction_flow=mock_interaction_flow,
+            bot_user_id="U123456"
+        )
+        assert processor.allowed_channels is None
+
+    @pytest.mark.asyncio
+    async def test_process_message_in_allowed_channel(
+        self, mock_interaction_flow, mock_say_fn, mock_client
+    ):
+        """Test that messages in allowed channels are processed."""
+        allowed_channels = ["C1234567", "C2345678"]
+        processor = SlackEventProcessor(
+            interaction_flow=mock_interaction_flow,
+            bot_user_id="U123456",
+            allowed_channels=allowed_channels
+        )
+
+        event_data = {
+            "channel_type": "channel",
+            "channel": "C1234567",  # Allowed channel
+            "user": "U999999",
+            "text": "<@U123456> こんにちは",
+            "ts": "1234567890.123"
+        }
+
+        await processor.process_message_event(event_data, mock_say_fn, mock_client)
+
+        # Verify that the interaction flow was called
+        mock_interaction_flow.get_agent_response_stream.assert_called_once()
+        # Verify that say function was called
+        mock_say_fn.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_process_message_in_disallowed_channel(
+        self, mock_interaction_flow, mock_say_fn, mock_client
+    ):
+        """Test that messages in disallowed channels are ignored."""
+        allowed_channels = ["C1234567", "C2345678"]
+        processor = SlackEventProcessor(
+            interaction_flow=mock_interaction_flow,
+            bot_user_id="U123456",
+            allowed_channels=allowed_channels
+        )
+
+        event_data = {
+            "channel_type": "channel",
+            "channel": "C9999999",  # Not in allowed channels
+            "user": "U999999",
+            "text": "<@U123456> こんにちは",
+            "ts": "1234567890.123"
+        }
+
+        await processor.process_message_event(event_data, mock_say_fn, mock_client)
+
+        # Verify that the interaction flow was NOT called
+        mock_interaction_flow.get_agent_response_stream.assert_not_called()
+        # Verify that say function was NOT called
+        mock_say_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_message_when_no_whitelist_configured(
+        self, mock_interaction_flow, mock_say_fn, mock_client
+    ):
+        """Test that all channels are allowed when no whitelist is configured."""
+        processor = SlackEventProcessor(
+            interaction_flow=mock_interaction_flow,
+            bot_user_id="U123456",
+            allowed_channels=None  # No whitelist
+        )
+
+        event_data = {
+            "channel_type": "channel",
+            "channel": "C9999999",  # Any channel should work
+            "user": "U999999",
+            "text": "<@U123456> こんにちは",
+            "ts": "1234567890.123"
+        }
+
+        await processor.process_message_event(event_data, mock_say_fn, mock_client)
+
+        # Verify that the interaction flow was called
+        mock_interaction_flow.get_agent_response_stream.assert_called_once()
+        # Verify that say function was called
+        mock_say_fn.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_direct_message_also_respects_whitelist(
+        self, mock_interaction_flow, mock_say_fn, mock_client
+    ):
+        """Test that direct messages are also filtered by whitelist when configured."""
+        allowed_channels = ["C1234567"]
+        processor = SlackEventProcessor(
+            interaction_flow=mock_interaction_flow,
+            bot_user_id="U123456",
+            allowed_channels=allowed_channels
+        )
+
+        event_data = {
+            "channel_type": "im",  # Direct message
+            "channel": "D9999999",  # DM channel (not in whitelist)
+            "user": "U999999",
+            "text": "こんにちは",
+            "ts": "1234567890.123"
+        }
+
+        await processor.process_message_event(event_data, mock_say_fn, mock_client)
+
+        # Verify that the interaction flow was NOT called (DMs should respect whitelist)
+        mock_interaction_flow.get_agent_response_stream.assert_not_called()
+        # Verify that say function was NOT called
+        mock_say_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_direct_message_in_allowed_channel(
+        self, mock_interaction_flow, mock_say_fn, mock_client
+    ):
+        """Test that direct messages work when DM channel is in whitelist."""
+        allowed_channels = ["C1234567", "D9999999"]  # Include DM channel in whitelist
+        processor = SlackEventProcessor(
+            interaction_flow=mock_interaction_flow,
+            bot_user_id="U123456",
+            allowed_channels=allowed_channels
+        )
+
+        event_data = {
+            "channel_type": "im",  # Direct message
+            "channel": "D9999999",  # DM channel (in whitelist)
+            "user": "U999999",
+            "text": "こんにちは",
+            "ts": "1234567890.123"
+        }
+
+        await processor.process_message_event(event_data, mock_say_fn, mock_client)
+
+        # Verify that the interaction flow was called
+        mock_interaction_flow.get_agent_response_stream.assert_called_once()
+        # Verify that say function was called
+        mock_say_fn.assert_called()


### PR DESCRIPTION
## Summary
- Add channel whitelist functionality to restrict bot responses to specific channels
- Configuration via `ALLOWED_CHANNELS` environment variable (comma-separated channel IDs)
- Applies to both regular channels and DMs when configured
- Comprehensive test coverage with TDD approach

## Changes
- **Config**: Add `allowed_channels` field to `AdkSlackConfig` with environment variable support
- **Event Processing**: Implement channel filtering in `SlackEventProcessor`
- **Integration**: Update `AdkSlackAppRunner` to pass allowed channels configuration
- **Documentation**: Update `.env.example` with usage instructions
- **Tests**: Complete test suite for whitelist functionality
- **Security**: Add `.claude/` to `.gitignore` to prevent sensitive configuration exposure

## Test plan
- [x] Unit tests for configuration loading from environment variables
- [x] Unit tests for SlackEventProcessor channel filtering logic
- [x] Integration tests for allowed/disallowed channels and DMs
- [x] All existing tests continue to pass
- [x] Code quality checks (ruff, mypy) pass

## Usage
```bash
# Allow bot to respond only in specific channels
ALLOWED_CHANNELS=C1234567890,C0987654321,D1122334455

# If not set, bot responds in all channels (existing behavior)
```

🤖 Generated with [Claude Code](https://claude.ai/code)